### PR TITLE
Add Docker support for Django and Vue.js projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Python image as the base image
+FROM python:3.9
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt /app/
+
+# Install dependencies
+RUN pip install -r requirements.txt
+
+# Copy the Django project files into the container
+COPY . /app/
+
+# Expose port 8000
+EXPOSE 8000
+
+# Run the Django development server
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/app/vueapp/Dockerfile
+++ b/app/vueapp/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Node.js image as the base image
+FROM node:14
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the package.json and package-lock.json files to the container
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the Vue.js project files to the container
+COPY . .
+
+# Expose port 8080
+EXPOSE 8080
+
+# Run the Vue.js development server
+CMD ["npm", "run", "serve"]

--- a/csmcore/settings.py
+++ b/csmcore/settings.py
@@ -21,12 +21,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-_(plw^z*dm-7w21@97f59j&x47q&@o1825qgf%4k3e)6cu1vjy'
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', 'True') == 'True'
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '').split(',')
 
 
 # Application definition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+  django:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: django
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    networks:
+      - app-network
+
+  vueapp:
+    build:
+      context: ./app/vueapp
+      dockerfile: Dockerfile
+    container_name: vueapp
+    command: npm run serve
+    volumes:
+      - ./app/vueapp:/app
+    ports:
+      - "8080:8080"
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
Add Docker configuration files and update Django settings for environment variables.

* **Dockerfile for Django project**
  - Use the official Python image as the base image
  - Set the working directory to /app
  - Copy the requirements file into the container
  - Install dependencies
  - Copy the Django project files into the container
  - Expose port 8000
  - Run the Django development server

* **Dockerfile for Vue.js project**
  - Use the official Node.js image as the base image
  - Set the working directory to /app
  - Copy the package.json and package-lock.json files to the container
  - Install dependencies
  - Copy the Vue.js project files to the container
  - Expose port 8080
  - Run the Vue.js development server

* **docker-compose.yml**
  - Define services for Django and Vue.js projects
  - Set up a network for the services to communicate
  - Use environment variables for sensitive data

* **Django settings update**
  - Replace hardcoded `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS` values with environment variables

